### PR TITLE
Added option for user to specify specific server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ You will need a [NordVPN](https://nordvpn.com) account.
 - `LOAD` If the load is > 75 on a NordVPN server, OpenVPN will be restarted and connects to the recommended server for you! This check will be done every 15 minutes by CRON.
 - `COUNTRY` *Optional*, you can choose your own country by using the two-letter country codes that are supported by NordVPN.
 - `PROTOCOL` *Optional*, default set to `tcp`, you can change it to `udp`.
+- `SERVER` *Optional*, if not set, connects to the recommended server for you. If set, connects to the server you specify. Example server name format: `us2484.nordvpn.com`.
 
 
 ## Start container

--- a/app/ovpn/servers_recommendations.sh
+++ b/app/ovpn/servers_recommendations.sh
@@ -6,37 +6,52 @@
 JSON_FILE=/tmp/servers_recommendations.json
 JSON_FILE_SERVER_COUNTRIES=/tmp/servers_countries
 
+# If no server was set, choose the best
+if [[ ! -v SERVER ]]; then
+    echo "$(adddate) INFO: SERVER has not been set, choosing best for you."
+    if [ -z "$COUNTRY" ]
+        then 
+            echo "$(adddate) INFO: No country has been set. The default will be picked by NordVPN API. If you want to use a country, please use e.g. COUNTRY=it"
+            #GET fastest server based on NordVPN API
+            #https://nordvpn.com/wp-admin/admin-ajax.php?action=servers_recommendations
+            curl -s $SERVER_RECOMMENDATIONS_URL -o $JSON_FILE
+        else
+            echo "$(adddate) INFO: Your country setting will be used. This is set to: ${COUNTRY^^}"
 
-if [ -z "$COUNTRY" ]
-    then 
-        echo "$(adddate) INFO: No country has been set. The default will be picked by NordVPN API. If you want to use a country, please use e.g. COUNTRY=it"
-        #GET fastest server based on NordVPN API
-        #https://nordvpn.com/wp-admin/admin-ajax.php?action=servers_recommendations
-        curl -s $SERVER_RECOMMENDATIONS_URL -o $JSON_FILE
-    else
-        echo "$(adddate) INFO: Your country setting will be used. This is set to: ${COUNTRY^^}"
+            #Country codes will only be fetched once. You can force to get a new list to start a new container
+            #This will speed up the process
+            if [ -f "$JSON_FILE_SERVER_COUNTRIES" ]
+                then
+                    echo "$(adddate) INFO: The country codes are known, skipping"
+                    export COUNTRY_CODE=$(cat $JSON_FILE_SERVER_COUNTRIES | jq '.[]  | select(.code == "'${COUNTRY^^}'") | .id')
+                else 
+                    echo "$(adddate) INFO: The country codes are unknown, getting country codes from API"
+                    curl -s https://nordvpn.com/wp-admin/admin-ajax.php?action=servers_countries -o /tmp/servers_countries
+                    export COUNTRY_CODE=$(cat $JSON_FILE_SERVER_COUNTRIES | jq '.[]  | select(.code == "'${COUNTRY^^}'") | .id')
+            fi
+          
+          #GET fastest server based on COUNTRY
+          #https://nordvpn.com/wp-admin/admin-ajax.php?action=servers_recommendations&filters={%22country_id%22:106}
+          wget --quiet --header 'cache-control: no-cache' --output-document=$JSON_FILE ''$SERVER_RECOMMENDATIONS_URL'&filters={%22country_id%22:'$COUNTRY_CODE'}'
+    fi
 
-        #Country codes will only be fetched once. You can force to get a new list to start a new container
-        #This will speed up the process
-        if [ -f "$JSON_FILE_SERVER_COUNTRIES" ]
-            then
-                echo "$(adddate) INFO: The country codes are known, skipping"
-                export COUNTRY_CODE=$(cat $JSON_FILE_SERVER_COUNTRIES | jq '.[]  | select(.code == "'${COUNTRY^^}'") | .id')
-            else 
-                echo "$(adddate) INFO: The country codes are unknown, getting country codes from API"
-                curl -s https://nordvpn.com/wp-admin/admin-ajax.php?action=servers_countries -o /tmp/servers_countries
-                export COUNTRY_CODE=$(cat $JSON_FILE_SERVER_COUNTRIES | jq '.[]  | select(.code == "'${COUNTRY^^}'") | .id')
-        fi
-        
-        #GET fastest server based on COUNTRY
-        #https://nordvpn.com/wp-admin/admin-ajax.php?action=servers_recommendations&filters={%22country_id%22:106}
-        wget --quiet --header 'cache-control: no-cache' --output-document=$JSON_FILE ''$SERVER_RECOMMENDATIONS_URL'&filters={%22country_id%22:'$COUNTRY_CODE'}'
+    #Set vars
+    export SERVER="$(jq -r '.[0].hostname' $JSON_FILE)"
+    export SERVERNAME="$(jq -r '.[0].name' $JSON_FILE)"
+    export LOAD="$(jq -r '.[0].load' $JSON_FILE)"
+    export UPDATED_AT="$(jq -r '.[0].updated_at' $JSON_FILE)"
+    export IP="$(jq -r '.[0].station' $JSON_FILE)"
+    echo "$(jq -r '.[0].hostname' $JSON_FILE)" > /tmp/nordvpn_hostname
+
+# Otherwise, use the server that was specified
+else
+    echo "$(adddate) INFO: SERVER has been set to ${SERVER^^}"
+    curl --silent https://api.nordvpn.com/server | jq '.[] | select(.domain == '\"$SERVER\"')' > $JSON_FILE
+
+    #Set vars
+    export SERVERNAME="$(jq -r '.name' $JSON_FILE)"
+    export LOAD=$(curl -s $SERVER_STATS_URL$SERVER | jq -r '.[]')
+    export UPDATED_AT=""
+    export IP="$(jq -r '.ip_address' $JSON_FILE)"
+    echo "$SERVER" > /tmp/nordvpn_hostname
 fi
-
-#Set vars
-export SERVER="$(jq -r '.[0].hostname' $JSON_FILE)"
-export SERVERNAME="$(jq -r '.[0].name' $JSON_FILE)"
-export LOAD="$(jq -r '.[0].load' $JSON_FILE)"
-export UPDATED_AT="$(jq -r '.[0].updated_at' $JSON_FILE)"
-export IP="$(jq -r '.[0].station' $JSON_FILE)"
-echo "$(jq -r '.[0].hostname' $JSON_FILE)" > /tmp/nordvpn_hostname


### PR DESCRIPTION
## What's New

This PR allows the user to optionally set an environment variable `SERVER` when they run the container (through `docker run` or in their `docker-compose.yml`).

If `SERVER` is not set, the default behavior of selecting the best server ensues.

If `SERVER` is set (for example, `SERVER=us2484.nordvpn.com`) then `us2484.nordvpn.com` is connected to until the specified load is exceeded.

## How is this useful
A user may want to specify a server in a specific city.

Also, for some tasks, it may be beneficial to periodically rotate the VPN address. This _could_ be managed by the container with some `randomize` flag, or it can be managed by an external process. This PR allows the user to control this connection criteria through an external process.

