### PR TITLE
Creating tun device /dev/net/tun if not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ You will need a [NordVPN](https://nordvpn.com) account.
 ```Shell
 docker run -d \
 --cap-add=NET_ADMIN \
---device=/dev/net/tun \
 --name=vpn \
 --dns=103.86.96.100 \
 --dns=103.86.99.100 \

--- a/app/ovpn/run
+++ b/app/ovpn/run
@@ -6,6 +6,14 @@ source /app/ovpn/servers_recommendations.sh
 
 . /app/date.sh --source-only
 
+# Create a tun device see: https://www.kernel.org/doc/Documentation/networking/tuntap.txt
+if [ ! -c /dev/net/tun ]; then
+    echo "$(adddate) INFO: Creating tun interface /dev/net/tun"
+    mkdir -p /dev/net
+    mknod /dev/net/tun c 10 200
+    chmod 600 /dev/net/tun
+fi
+
 echo ########################################################
 echo "$(adddate) INFO: Connection to server: $SERVERNAME"
 echo "$(adddate) INFO: Current load: $LOAD"


### PR DESCRIPTION
Hello,

First thank you for this *amazing repo* :smiley: 
I wanted to ass my contribution to make the argument `--device`. In my understanding, this argument creates a device volume between the host and the container. It can be difficult to support that in some environment (like in Kubernetes).

It's just easier to create the device with mknod directly in the container. The capability NET_ADMIN is still necessary !
More information here:
https://www.kernel.org/doc/Documentation/networking/tuntap.txt

I have pushed this on [DockerHub](https://hub.docker.com/r/murattuw/nordvpn-proxy) (Tag: murattuw/nordvpn-proxy:optional_tun_device)

The following works:
```
docker run --rm -d \
        --cap-add=NET_ADMIN \
        --name=vpn \
        --dns=103.86.96.100 \
        --dns=103.86.99.100 \
        -e "USERNAME=$nordvpn_username" \
        -e "PASSWORD=$nordvpn_password" \
        -p "127.0.0.1:8118":8118 \
        murattuw/nordvpn-proxy:optional_tun_device
```

Best regards,