### PR TITLE
Fix configuration via SERVER environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,5 @@ RUN \
 
 CMD ["runsvdir", "/app"]
 
-HEALTHCHECK --interval=1m --timeout=10s \
-  CMD if [[ $( curl -x localhost:8118 https://api.nordvpn.com/vpn/check/full | jq -r '.["status"]' ) = "Protected" ]] ; then exit 0; else exit 1; fi
+HEALTHCHECK --interval=10m --timeout=10s \
+  CMD ["sh", "/app/healthcheck.sh"]

--- a/README.md
+++ b/README.md
@@ -100,5 +100,6 @@ RANDOM_TOP=100
 ```
 
 ## Contribution
+The healthcheck of this container originally used a [NordVPN api that has been deprecated](https://support.nordvpn.com/hc/en-us/articles/21586950310801-Discontinuation-of-the-legacy-API-endpoints-on-NordVPN). The new healthcheck now involves comparing the IPv4 address obtlained by querying [ifconfig.me](ifconfig.me) with and without the proxy.
 
 Feel free to fork and contribute, or submit an issue.

--- a/app/healthcheck.sh
+++ b/app/healthcheck.sh
@@ -1,0 +1,4 @@
+proxied=$( curl -s -x localhost:8118 ifconfig.me )
+non_proxied=$( curl -s -4 ifconfig.me )
+
+if [[ $proxied = $non_proxied ]]; then exit 1; else exit 0; fi

--- a/app/ovpn/servers_recommendations.sh
+++ b/app/ovpn/servers_recommendations.sh
@@ -61,7 +61,7 @@ if [[ ! -v SERVER ]]; then
 # Otherwise, use the server that was specified
 else
     echo "$(adddate) INFO: SERVER has been set to ${SERVER^^}"
-    curl --silent https://api.nordvpn.com/server | jq '.[] | select(.domain == '\"$SERVER\"')' > $JSON_FILE
+    curl --silent https://api.nordvpn.com/v1/servers?limit=0 | jq '.[] | select(.hostname == '\"$SERVER\"')' > $JSON_FILE
 
     #Set vars
     export SERVERNAME="$(jq -r '.name' $JSON_FILE)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   vpn:
-    image: jeroenslot/nordvpn-proxy:latest
+    image: 9yifanchen9/nordvpn-proxy:latest
     cap_add:
       - NET_ADMIN
     devices:


### PR DESCRIPTION
Previously, the API endpoint "https://api.nordvpn.com/server", which was used to select the server based on SERVER environment variable, is now deprecated. The new API https://api.nordvpn.com/v1/servers provides domain information under field "hostname".